### PR TITLE
Add notification and clear features

### DIFF
--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { TargetInfo, CheckResult, Settings } from '@/types';
+import { useState, useEffect, useCallback } from "react";
+import { TargetInfo, CheckResult, Settings } from "@/types";
 
 export function useChecks(timeframeHours: number, frequency: number) {
   const [checks, setChecks] = useState<CheckResult[]>([]);
@@ -11,16 +11,16 @@ export function useChecks(timeframeHours: number, frequency: number) {
       if (!isBackground) {
         setLoading(true);
       }
-      const response = await fetch('/api/checks');
+      const response = await fetch("/api/checks");
       if (!response.ok) {
-        throw new Error('Failed to fetch checks');
+        throw new Error("Failed to fetch checks");
       }
       const data = await response.json();
       setChecks(data || []);
       if (!isBackground) setError(null);
     } catch (err) {
       if (!isBackground)
-        setError(err instanceof Error ? err.message : 'Unknown error');
+        setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       if (!isBackground) {
         setLoading(false);
@@ -51,15 +51,15 @@ export function useSettings() {
   const fetchSettings = async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/settings');
+      const response = await fetch("/api/settings");
       if (!response.ok) {
-        throw new Error('Failed to fetch settings');
+        throw new Error("Failed to fetch settings");
       }
       const data = await response.json();
       setSettings(data);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
+      setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
     }
@@ -67,20 +67,20 @@ export function useSettings() {
 
   const updateSettings = async (newSettings: Settings) => {
     try {
-      const response = await fetch('/api/settings', {
-        method: 'POST',
+      const response = await fetch("/api/settings", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify(newSettings),
       });
       if (!response.ok) {
-        throw new Error('Failed to update settings');
+        throw new Error("Failed to update settings");
       }
       setSettings(newSettings);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
+      setError(err instanceof Error ? err.message : "Unknown error");
     }
   };
 
@@ -99,64 +99,88 @@ export function useTargets() {
   const fetchTargets = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/targets');
+      const response = await fetch("/api/targets");
       if (!response.ok) {
-        throw new Error('Failed to fetch targets');
+        throw new Error("Failed to fetch targets");
       }
       const data = await response.json();
       setTargets(data || []);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
+      setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
     }
   }, []);
 
-  const addTarget = async (target: Omit<TargetInfo, 'id'>) => {
+  const addTarget = async (target: Omit<TargetInfo, "id">) => {
     try {
-      const response = await fetch('/api/targets', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const response = await fetch("/api/targets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(target),
       });
       if (!response.ok) {
-        throw new Error('Failed to add target');
+        throw new Error("Failed to add target");
       }
       await fetchTargets(); // Refresh the list
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
+      setError(err instanceof Error ? err.message : "Unknown error");
     }
   };
 
   const updateTarget = async (target: TargetInfo) => {
     try {
       const response = await fetch(`/api/targets`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(target),
       });
       if (!response.ok) {
-        throw new Error('Failed to update target');
+        throw new Error("Failed to update target");
       }
       await fetchTargets(); // Refresh the list
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
+      setError(err instanceof Error ? err.message : "Unknown error");
     }
   };
 
   const deleteTarget = async (id: number) => {
     try {
       const response = await fetch(`/api/targets?id=${id}`, {
-        method: 'DELETE',
+        method: "DELETE",
       });
       if (!response.ok) {
-        throw new Error('Failed to delete target');
+        throw new Error("Failed to delete target");
       }
       await fetchTargets(); // Refresh the list
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
+      setError(err instanceof Error ? err.message : "Unknown error");
     }
+  };
+
+  const clearChecks = async (target: string) => {
+    try {
+      await fetch(`/api/targets/clear?target=${encodeURIComponent(target)}`, {
+        method: "POST",
+      });
+      await fetchTargets();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const subscribeTarget = async (id: number) => {
+    try {
+      await fetch(`/api/targets/subscribe?id=${id}`, { method: "POST" });
+      await fetchTargets();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const testTelegram = async () => {
+    await fetch("/api/test-telegram", { method: "POST" });
   };
 
   useEffect(() => {
@@ -171,5 +195,8 @@ export function useTargets() {
     addTarget,
     updateTarget,
     deleteTarget,
+    clearChecks,
+    subscribeTarget,
+    testTelegram,
   };
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,8 +16,8 @@ export interface Service {
   id: string;
   name: string;
   url: string;
-  type: 'http' | 'postgres' | 'redis';
-  status: 'up' | 'down' | 'degraded';
+  type: "http" | "postgres" | "redis";
+  status: "up" | "down" | "degraded";
   responseTime: number;
   uptime: number;
   lastChecked: Date;
@@ -25,7 +25,7 @@ export interface Service {
   history: Array<{
     timestamp: Date;
     responseTime: number;
-    status: 'up' | 'down' | 'degraded';
+    status: "up" | "down" | "degraded";
   }>;
 }
 
@@ -33,9 +33,10 @@ export interface TargetInfo {
   id: number;
   name: string;
   url: string;
-  type: 'http' | 'postgres' | 'redis';
+  type: "http" | "postgres" | "redis";
   username?: string;
   password?: string;
+  subscribed?: boolean;
 }
 
 export interface ApiResponse<T> {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -39,9 +39,12 @@ func monitorLoop() {
 
 		freq := GetFrequency()
 		for _, t := range targets {
-			res := t.Check()
+			res := t.Probe.Check()
 			if err := storage.SaveCheck(res); err != nil {
 				log.Println("save error:", err)
+			}
+			if !res.Status && t.Subscribed {
+				notifyDown(t.Name)
 			}
 		}
 

--- a/server/run.go
+++ b/server/run.go
@@ -12,6 +12,11 @@ func Run() error {
 	if err := storage.Init(); err != nil {
 		return err
 	}
+	if s, err := storage.GetSettings(); err == nil {
+		mu.Lock()
+		settings = &Settings{Frequency: s.Frequency, TimeframeHours: s.TimeframeHours}
+		mu.Unlock()
+	}
 	StartMonitoring()
 
 	mux := http.NewServeMux()

--- a/server/telegram.go
+++ b/server/telegram.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+var lastSent = make(map[string]time.Time)
+
+func sendTelegram(msg string) error {
+	token := os.Getenv("TELEGRAM_BOT_TOKEN")
+	chatID := os.Getenv("TELEGRAM_CHAT_ID")
+	if token == "" || chatID == "" {
+		return nil
+	}
+	data := url.Values{}
+	data.Set("chat_id", chatID)
+	data.Set("text", msg)
+	_, err := http.PostForm("https://api.telegram.org/bot"+token+"/sendMessage", data)
+	return err
+}
+
+func notifyDown(resource string) {
+	now := time.Now()
+	if t, ok := lastSent[resource]; ok {
+		if now.Sub(t) < 24*time.Hour && now.Day() == t.Day() {
+			return
+		}
+	}
+	if err := sendTelegram("Resource down: " + resource); err == nil {
+		lastSent[resource] = now
+	}
+}
+
+func testTelegram() {
+	_ = sendTelegram("Test notification from Uptime Monitor")
+}

--- a/storage/db.go
+++ b/storage/db.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"strings"
 	"time"
 
 	"uptime/probes"
@@ -10,6 +11,14 @@ import (
 )
 
 var db *sql.DB
+
+// MonitorTarget combines probe with metadata
+type MonitorTarget struct {
+	Probe      probes.Target
+	Name       string
+	URL        string
+	Subscribed bool
+}
 
 func Init() error {
 	var err error
@@ -22,7 +31,7 @@ func Init() error {
 
 func createSchema() error {
 	_, err := db.Exec(`
-	CREATE TABLE IF NOT EXISTS checks (
+        CREATE TABLE IF NOT EXISTS checks (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         target TEXT,
         type TEXT,
@@ -31,15 +40,33 @@ func createSchema() error {
         checked_at DATETIME,
         message TEXT
     );
-	CREATE TABLE IF NOT EXISTS targets (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		name TEXT,
-		url TEXT,
-		type TEXT,
-		username TEXT,
-		password TEXT
-	);
-	`)
+        CREATE TABLE IF NOT EXISTS targets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT,
+                url TEXT,
+                type TEXT,
+                username TEXT,
+                password TEXT,
+                subscribed INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS settings (
+                id INTEGER PRIMARY KEY,
+                frequency INTEGER,
+                timeframe INTEGER
+        );
+        `)
+	if err != nil {
+		return err
+	}
+
+	// Attempt to add subscribed column if missing
+	_, err = db.Exec(`ALTER TABLE targets ADD COLUMN subscribed INTEGER DEFAULT 0`)
+	if err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return err
+	}
+
+	// Insert default settings if not exist
+	_, err = db.Exec(`INSERT INTO settings(id, frequency, timeframe) VALUES(1, 60, 24) ON CONFLICT(id) DO NOTHING`)
 	return err
 }
 
@@ -56,29 +83,32 @@ func boolToInt(b bool) int {
 	return 0
 }
 
-func GetTargets() ([]probes.Target, error) {
-	rows, err := db.Query(`SELECT id, name, url, type, username, password FROM targets`)
+func GetTargets() ([]MonitorTarget, error) {
+	rows, err := db.Query(`SELECT id, name, url, type, username, password, subscribed FROM targets`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var targets []probes.Target
+	var targets []MonitorTarget
 	for rows.Next() {
 		var id int
 		var name, url, typ string
 		var username, password sql.NullString // Use sql.NullString for nullable columns
-		if err := rows.Scan(&id, &name, &url, &typ, &username, &password); err != nil {
+		var subscribed int
+		if err := rows.Scan(&id, &name, &url, &typ, &username, &password, &subscribed); err != nil {
 			return nil, err
 		}
+		var probe probes.Target
 		switch typ {
 		case "http":
-			targets = append(targets, probes.HTTP{URL: url})
+			probe = probes.HTTP{URL: url}
 		case "postgres":
-			targets = append(targets, probes.Postgres{Addr: url, User: username.String, Pass: password.String, DB: "postgres"})
+			probe = probes.Postgres{Addr: url, User: username.String, Pass: password.String, DB: "postgres"}
 		case "redis":
-			targets = append(targets, probes.Redis{Addr: url, User: username.String, Pass: password.String})
+			probe = probes.Redis{Addr: url, User: username.String, Pass: password.String}
 		}
+		targets = append(targets, MonitorTarget{Probe: probe, Name: name, URL: url, Subscribed: subscribed == 1})
 	}
 
 	if len(targets) == 0 {
@@ -88,7 +118,7 @@ func GetTargets() ([]probes.Target, error) {
 	return targets, nil
 }
 
-func insertDefaultTargets() ([]probes.Target, error) {
+func insertDefaultTargets() ([]MonitorTarget, error) {
 	defaultTargets := []struct {
 		Name string
 		URL  string
@@ -106,13 +136,13 @@ func insertDefaultTargets() ([]probes.Target, error) {
 		return nil, err
 	}
 	// Add username and password to the insert statement
-	stmt, err := tx.Prepare("INSERT INTO targets(name, url, type, username, password) VALUES(?, ?, ?, ?, ?)")
+	stmt, err := tx.Prepare("INSERT INTO targets(name, url, type, username, password, subscribed) VALUES(?, ?, ?, ?, ?, 0)")
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 
-	var targets []probes.Target
+	var targets []MonitorTarget
 	for _, t := range defaultTargets {
 		var user, pass string
 		// Add dummy credentials for local DBs for the defaults
@@ -125,14 +155,16 @@ func insertDefaultTargets() ([]probes.Target, error) {
 			tx.Rollback()
 			return nil, err
 		}
+		var probe probes.Target
 		switch t.Type {
 		case "http":
-			targets = append(targets, probes.HTTP{URL: t.URL})
+			probe = probes.HTTP{URL: t.URL}
 		case "postgres":
-			targets = append(targets, probes.Postgres{Addr: t.URL, User: user, Pass: pass, DB: "postgres"})
+			probe = probes.Postgres{Addr: t.URL, User: user, Pass: pass, DB: "postgres"}
 		case "redis":
-			targets = append(targets, probes.Redis{Addr: t.URL, User: user, Pass: pass})
+			probe = probes.Redis{Addr: t.URL, User: user, Pass: pass}
 		}
+		targets = append(targets, MonitorTarget{Probe: probe, Name: t.Name, URL: t.URL, Subscribed: false})
 	}
 	tx.Commit()
 
@@ -140,17 +172,18 @@ func insertDefaultTargets() ([]probes.Target, error) {
 }
 
 type TargetInfo struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	URL      string `json:"url"`
-	Type     string `json:"type"`
-	Username string `json:"username,omitempty"`
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	URL        string `json:"url"`
+	Type       string `json:"type"`
+	Username   string `json:"username,omitempty"`
+	Subscribed bool   `json:"subscribed"`
 	// Password is intentionally omitted for security
 }
 
 func GetTargetInfos() ([]TargetInfo, error) {
 	// Select the new columns but don't expose password
-	rows, err := db.Query(`SELECT id, name, url, type, username FROM targets ORDER BY id`)
+	rows, err := db.Query(`SELECT id, name, url, type, username, subscribed FROM targets ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -159,16 +192,18 @@ func GetTargetInfos() ([]TargetInfo, error) {
 	var targets []TargetInfo
 	for rows.Next() {
 		var t TargetInfo
-		if err := rows.Scan(&t.ID, &t.Name, &t.URL, &t.Type, &t.Username); err != nil {
+		var subscribed int
+		if err := rows.Scan(&t.ID, &t.Name, &t.URL, &t.Type, &t.Username, &subscribed); err != nil {
 			return nil, err
 		}
+		t.Subscribed = subscribed == 1
 		targets = append(targets, t)
 	}
 	return targets, nil
 }
 
 func AddTarget(name, url, typ, username, password string) error {
-	_, err := db.Exec("INSERT INTO targets(name, url, type, username, password) VALUES(?, ?, ?, ?, ?)", name, url, typ, username, password)
+	_, err := db.Exec("INSERT INTO targets(name, url, type, username, password, subscribed) VALUES(?, ?, ?, ?, ?, 0)", name, url, typ, username, password)
 	return err
 }
 
@@ -184,6 +219,16 @@ func UpdateTarget(id int, name, url, typ, username, password string) error {
 
 func DeleteTarget(id int) error {
 	_, err := db.Exec("DELETE FROM targets WHERE id = ?", id)
+	return err
+}
+
+func SubscribeTarget(id int) error {
+	_, err := db.Exec("UPDATE targets SET subscribed = 1 WHERE id = ?", id)
+	return err
+}
+
+func ClearChecks(target string) error {
+	_, err := db.Exec("DELETE FROM checks WHERE target = ?", target)
 	return err
 }
 
@@ -218,4 +263,34 @@ func LastChecks(hours int) ([]probes.Result, error) {
 		res = append(res, r)
 	}
 	return res, nil
+}
+
+// Settings persistence
+type Settings struct {
+	Frequency      int
+	TimeframeHours int
+}
+
+func GetSettings() (*Settings, error) {
+	row := db.QueryRow("SELECT frequency, timeframe FROM settings WHERE id=1")
+	var s Settings
+	if err := row.Scan(&s.Frequency, &s.TimeframeHours); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func UpdateSettings(freq, timeframe int) error {
+	res, err := db.Exec("UPDATE settings SET frequency=?, timeframe=? WHERE id=1", freq, timeframe)
+	if err != nil {
+		return err
+	}
+	c, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if c == 0 {
+		_, err = db.Exec("INSERT INTO settings(id, frequency, timeframe) VALUES(1, ?, ?)", freq, timeframe)
+	}
+	return err
 }


### PR DESCRIPTION
## Summary
- persist settings in sqlite and load them on startup
- add Telegram notifier with daily limit
- expose subscribe and clear endpoints
- extend targets with subscribed property
- update React app to clear history, subscribe to alerts, and send test Telegram message

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68503a5ed3e8832aaed803ff19217826