### PR TITLE
Improve subscriptions and timeframe charts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import {
   Plus,
   Trash2,
   Edit2,
+  Eraser,
+  BellOff,
   MoreHorizontal,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -54,6 +56,7 @@ function App() {
     deleteTarget,
     clearChecks,
     subscribeTarget,
+    unsubscribeTarget,
     testTelegram,
   } = useTargets();
   const {
@@ -363,10 +366,17 @@ function App() {
                         <DropdownMenuItem
                           onClick={() => clearChecks(service.url)}
                         >
-                          <Trash2 className="mr-2 h-4 w-4" />
+                          <Eraser className="mr-2 h-4 w-4" />
                           <span>Clear</span>
                         </DropdownMenuItem>
-                        {!service.subscribed && (
+                        {service.subscribed ? (
+                          <DropdownMenuItem
+                            onClick={() => unsubscribeTarget(service.id)}
+                          >
+                            <BellOff className="mr-2 h-4 w-4" />
+                            <span>Unsubscribe</span>
+                          </DropdownMenuItem>
+                        ) : (
                           <DropdownMenuItem
                             onClick={() => subscribeTarget(service.id)}
                           >
@@ -377,8 +387,8 @@ function App() {
                         <DropdownMenuItem
                           onClick={() => handleDeleteService(service.id)}
                         >
-                          <Trash2 className="mr-2 h-4 w-4" />
-                          <span>Delete</span>
+                          <Trash2 className="mr-2 h-4 w-4 text-red-600" />
+                          <span className="text-red-600">Delete</span>
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
@@ -422,10 +432,15 @@ function App() {
                     <ResponsiveContainer width="100%" height="100%">
                       <LineChart
                         data={service.checks
-                          .slice(-20)
+                          .slice()
                           .reverse()
                           .map((check) => ({
-                            time: format(new Date(check.checkedAt), "HH:mm"),
+                            time: format(
+                              new Date(check.checkedAt),
+                              settings.timeframeHours > 24
+                                ? "MM-dd HH:mm"
+                                : "HH:mm",
+                            ),
                             responseTime: check.status ? check.duration : null,
                           }))}
                       >

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -179,6 +179,15 @@ export function useTargets() {
     }
   };
 
+  const unsubscribeTarget = async (id: number) => {
+    try {
+      await fetch(`/api/targets/unsubscribe?id=${id}`, { method: "POST" });
+      await fetchTargets();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
   const testTelegram = async () => {
     await fetch("/api/test-telegram", { method: "POST" });
   };
@@ -197,6 +206,7 @@ export function useTargets() {
     deleteTarget,
     clearChecks,
     subscribeTarget,
+    unsubscribeTarget,
     testTelegram,
   };
 }

--- a/server/api.go
+++ b/server/api.go
@@ -30,6 +30,7 @@ func registerAPI(mux *http.ServeMux) {
 	mux.HandleFunc("/api/targets", handleTargets)
 	mux.HandleFunc("/api/targets/clear", handleClear)
 	mux.HandleFunc("/api/targets/subscribe", handleSubscribe)
+	mux.HandleFunc("/api/targets/unsubscribe", handleUnsubscribe)
 	mux.HandleFunc("/api/test-telegram", handleTestTelegram)
 }
 
@@ -195,6 +196,24 @@ func handleSubscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := storage.SubscribeTarget(id); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	idStr := r.URL.Query().Get("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	if err := storage.UnsubscribeTarget(id); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/storage/db.go
+++ b/storage/db.go
@@ -227,6 +227,11 @@ func SubscribeTarget(id int) error {
 	return err
 }
 
+func UnsubscribeTarget(id int) error {
+	_, err := db.Exec("UPDATE targets SET subscribed = 0 WHERE id = ?", id)
+	return err
+}
+
 func ClearChecks(target string) error {
 	_, err := db.Exec("DELETE FROM checks WHERE target = ?", target)
 	return err


### PR DESCRIPTION
## Summary
- support unsubscribing targets via API and storage
- add unsubscribe handler in server
- expose unsubscribeTarget in the frontend API hook
- update dropdown menu with Unsubscribe option and new icons
- render charts using entire timeframe

## Testing
- `go vet ./...`
- `go build ./cmd/uptime`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685061ce8490832a94459722a8bd5c90